### PR TITLE
Update framework from TP (#9)

### DIFF
--- a/Core/App.Console/ProgramBase.cs
+++ b/Core/App.Console/ProgramBase.cs
@@ -9,8 +9,7 @@ namespace Lens.Core.App.Console
     {
         protected static Action<HostBuilderContext, IApplicationSetupBuilder> ApplicationSetup { get; set; }
 
-        public static async Task<int> Start(string[] args) =>
-            await Start(args, CreateHostBuilder);
+        public static Task<int> Start(string[] args) => Start(args, CreateHostBuilder);
 
         protected static IHostBuilder CreateHostBuilder(string[] args) =>
                 CreateBaseHostBuilder(args)

--- a/Core/App.Web/Authentication/AuthenticationBase.cs
+++ b/Core/App.Web/Authentication/AuthenticationBase.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal abstract class AuthenticationBase<T> : IAuthententicationMethod where T : AuthSettings
+    {
+        public AuthenticationBase(T authSettings)
+        {
+            AuthSettings = authSettings ?? throw new ArgumentNullException(nameof(authSettings));
+        }
+
+        protected T AuthSettings { get; }
+
+        public virtual void UseMiddleware(IApplicationBuilder applicationBuilder) {
+            // default use authentication middleware (otherwise override it)
+            applicationBuilder.UseAuthentication();
+        }
+        
+        public virtual void ApplyMvcFilters(FilterCollection filters) { }
+
+        public virtual void Configure(IServiceCollection services, Action<AuthorizationOptions> authorizationOptions) { }
+
+        public virtual void ConfigureSwaggerAuth(SwaggerGenOptions options, SwaggerSettings swaggerSettings) { }
+
+        public virtual void UseSwaggerUI(SwaggerUIOptions options, SwaggerSettings swaggerSettings) { }
+
+    }
+}

--- a/Core/App.Web/Authentication/AuthenticationFactory.cs
+++ b/Core/App.Web/Authentication/AuthenticationFactory.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal static class AuthenticationFactory
+    {
+        private static readonly Dictionary<string, IAuthententicationMethod> methods = new Dictionary<string, IAuthententicationMethod>();
+        public static IAuthententicationMethod GetAuthenticationMethod(IConfiguration configuration)
+        {
+            var authSection = configuration.GetSection(nameof(AuthSettings));
+            return GetAuthenticationMethodByType(authSection, configuration);
+        }
+
+        private static IAuthententicationMethod GetAuthenticationMethodByType(IConfigurationSection authSection, IConfiguration configuration)
+        {
+            if (!authSection?.Exists() ?? false)
+            {
+                return InitializeAuthenticationMethod(AuthenticationMethod.Anonymous, () => new AnonymousAuthentication());
+            }
+
+            var type = authSection.GetValue<string>("AuthenticationType").ToLowerInvariant();
+
+
+            switch (type)
+            {
+                case AuthenticationMethod.OAuth2:
+                    return InitializeAuthenticationMethod(type, 
+                        () => new OAuth2Authentication<OAuthSettings>(authSection.Get<OAuthSettings>()));
+
+                case AuthenticationMethod.ApiKey:
+                    return InitializeAuthenticationMethod(type,
+                        () => new ApiKeyAuthentication<ApiKeyAuthSettings>(authSection.Get<ApiKeyAuthSettings>()));
+
+                case AuthenticationMethod.AzureAd:
+                    return InitializeAuthenticationMethod(type, 
+                        () => new AzureAuthentication<AzureAuthSettings>(authSection.Get<AzureAuthSettings>(), configuration));
+
+                default:
+                    throw new Exception($"No implementation found for auth method '{type}'. " +
+                                            "Update authentication type or add a new implementation");
+            }
+        }
+
+        private static IAuthententicationMethod InitializeAuthenticationMethod(string authenticationType, Func<IAuthententicationMethod> initAuthMethod)
+        {
+            methods.TryGetValue(authenticationType ?? string.Empty, out var method);
+            if (method == null)
+            {
+                method = initAuthMethod();
+                methods.Add(authenticationType, method);
+            }
+
+            return method;
+        }
+    }
+}

--- a/Core/App.Web/Authentication/Constants/AuthenticationMethod.cs
+++ b/Core/App.Web/Authentication/Constants/AuthenticationMethod.cs
@@ -1,0 +1,10 @@
+﻿namespace Lens.Core.App.Web.Authentication
+{
+    internal static class AuthenticationMethod
+    {
+        public const string OAuth2 = "oauth2";
+        public const string ApiKey = "apikey";
+        public const string AzureAd = "azuread";
+        public const string Anonymous = "anonymous";
+    }
+}

--- a/Core/App.Web/Authentication/Implementations/AnonymousAuthentication.cs
+++ b/Core/App.Web/Authentication/Implementations/AnonymousAuthentication.cs
@@ -1,0 +1,41 @@
+﻿using Lens.Core.Lib.Extensions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
+using System.Linq;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    /// <summary>
+    /// Used when there isn't configured any authentication configuration.
+    /// </summary>
+    /// <seealso cref="Lens.Core.App.Web.Authentication.IAuthententicationMethod" />
+    internal sealed class AnonymousAuthentication : IAuthententicationMethod
+    {
+        public void ApplyMvcFilters(FilterCollection filters)
+        {
+            foreach (var filter in filters.OrEmpty().ToArray())
+            {
+                if (filter is AuthorizeFilter)
+                {
+                    filters.Remove(filter);
+                }
+            }
+        }
+
+        public void Configure(IServiceCollection services, Action<AuthorizationOptions> authorizationOptions)
+        {
+            services.AddHttpContextAccessor();
+        }
+
+        public void ConfigureSwaggerAuth(SwaggerGenOptions options, SwaggerSettings swaggerSettings) { }
+        public void UseMiddleware(IApplicationBuilder applicationBuilder) { }
+        public void UseSwaggerUI(SwaggerUIOptions options, SwaggerSettings swaggerSettings) { }
+    }
+}

--- a/Core/App.Web/Authentication/Implementations/ApiKeyAuthentication.cs
+++ b/Core/App.Web/Authentication/Implementations/ApiKeyAuthentication.cs
@@ -1,0 +1,67 @@
+﻿using Lens.Core.App.Web.Middleware;
+using Lens.Core.Lib.Extensions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal class ApiKeyAuthentication<T> : AuthenticationBase<T> where T : ApiKeyAuthSettings
+    {
+        public ApiKeyAuthentication(T authSettings) : base(authSettings)
+        {
+        }
+
+        public override void UseMiddleware(IApplicationBuilder applicationBuilder)
+        {
+            // don't use the base one
+            applicationBuilder.UseMiddleware<ApiKeyMiddleware>();
+        }
+
+        public override void ConfigureSwaggerAuth(SwaggerGenOptions options, SwaggerSettings swaggerSettings)
+        {
+            base.ConfigureSwaggerAuth(options, swaggerSettings);
+
+            options.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme()
+            {
+                Type = SecuritySchemeType.ApiKey,
+                In = ParameterLocation.Header,
+                Name = this.AuthSettings.ApiKeyHeader,
+                Description = "API Key Authentication",
+            });
+
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" }
+                    },
+                    Array.Empty<string>()
+                }
+            });
+        }
+
+        public override void ApplyMvcFilters(FilterCollection filters)
+        {
+            base.ApplyMvcFilters(filters);
+
+
+            foreach (var filter in filters.OrEmpty().ToArray())
+            {
+                if (filter is AuthorizeFilter)
+                {
+                    filters.Remove(filter);
+                }
+            }
+        }
+    }
+}

--- a/Core/App.Web/Authentication/Implementations/AzureAuthentication.cs
+++ b/Core/App.Web/Authentication/Implementations/AzureAuthentication.cs
@@ -1,0 +1,148 @@
+﻿using Lens.Core.App.Web.Services;
+using Lens.Core.Lib.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal class AzureAuthentication<T> : OAuth2Authentication<T> where T : AzureAuthSettings
+    {
+        private const string ScopePolicyName = "ApiScopePolicy";
+        private const string RolePolicyName = "ApiRolePolicy";
+        private readonly IConfiguration configuration;
+
+        public AzureAuthentication(T authSettings, IConfiguration configuration) : base(authSettings)
+        {
+            this.configuration = configuration;
+        }
+
+        public override void ApplyMvcFilters(FilterCollection filters)
+        {
+            base.ApplyMvcFilters(filters);
+
+            if (this.AuthSettings.RequiredScopes.Any())
+            {
+                filters.Add(new AuthorizeFilter(ScopePolicyName));
+            }
+
+            if (this.AuthSettings.RequiredAppRoles.Any())
+            {
+                filters.Add(new AuthorizeFilter(RolePolicyName));
+            }
+        }
+
+        public override void Configure(
+            IServiceCollection services,
+            Action<AuthorizationOptions> authorizationOptions)
+        {
+            services.AddMicrosoftIdentityWebApiAuthentication(this.configuration, "AuthSettings");
+
+            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            {
+                if (this.AuthSettings.IncludeConfigInBearerHeader)
+                {
+                    var buildHeader = new StringBuilder("Bearer");
+                    if (!string.IsNullOrEmpty(this.AuthSettings.Authority))
+                    {
+                        buildHeader.AppendFormat(" authorization_uri=\"{0}authorize\"", this.AuthSettings.Authority);
+                    }
+
+                    if (!string.IsNullOrEmpty(this.AuthSettings.Resource))
+                    {
+                        buildHeader.AppendFormat(", resource=\"{0}\"", this.AuthSettings.Resource);
+                    }
+
+                    options.Challenge = buildHeader.ToString().Trim();
+                }
+                if (this.AuthSettings.AllowedIssuers.Any())
+                {
+                    // we need to override the default issuer validation in order to restrict access only for pre-configured allowed issuers
+                    // otherwise all Azure tenants are considered as valid issuer
+                    options.TokenValidationParameters.IssuerValidator = null;
+                    options.TokenValidationParameters.ValidIssuers = this.AuthSettings.AllowedIssuers;
+                    options.TokenValidationParameters.ValidateIssuer = true;
+                }
+
+                base.RegisterAuthenticationInterceptorEventHandlers(options);
+
+            });
+
+            services.AddAuthorization(
+                options =>
+                {
+                    options.AddPolicy(ScopePolicyName, ScopePolicy());
+                    options.AddPolicy(RolePolicyName, RolePolicy());
+                    options.FallbackPolicy = DefaultPolicy;
+
+                    authorizationOptions?.Invoke(options);
+                });
+
+            services.AddScoped<IUserContext, UserContext>();
+        }
+        
+        private Action<AuthorizationPolicyBuilder> ScopePolicy()
+        {
+            return policy => policy.RequireAssertion(
+                                        context =>
+                                        {
+                                            
+                                            var scopeClaim = context.User.FindFirst(ClaimConstants.Scope) ?? context.User.FindFirst(ClaimConstants.Scp);
+                                            if (scopeClaim == null)
+                                            {
+                                                /// For a confidential client, the value is 1 when a shared secret (a password) is used as a client secret (app authentication) and 
+                                                /// 2 when a certificate is used as a client secret (app authentication). 
+                                                /// The value 0 indicates a public client, which does not provide a client secret (user authentication)
+                                                var authType = context.User.FindFirst(ClaimConstants.Acr) ?? context.User.FindFirst("appidacr");
+
+                                                if (authType != null && (authType.Value == "1" || authType.Value == "2"))
+                                                {
+                                                    return true;
+                                                }
+                                                return false;
+                                            }
+
+                                            var incommingScopes = scopeClaim.Value.Split(' ');
+                                            var accessAllowed = this.AuthSettings.RequiredScopes.All(
+                                                s => incommingScopes.Contains(s));
+                                            return accessAllowed;
+                                        });
+        }
+
+        private Action<AuthorizationPolicyBuilder> RolePolicy()
+        {
+            return policy => policy.RequireAssertion(
+                                        context =>
+                                        {
+                                            var roleClaim = context.User.FindFirst(ClaimConstants.Role) ?? context.User.FindFirst(ClaimConstants.Roles);
+                                            if (roleClaim == null)
+                                            {
+                                                /// For a confidential client, the value is 1 when a shared secret (a password) is used as a client secret (app authentication) and 
+                                                /// 2 when a certificate is used as a client secret (app authentication). 
+                                                /// The value 0 indicates a public client, which does not provide a client secret (user authentication)
+                                                var authType = context.User.FindFirst(ClaimConstants.Acr) ?? context.User.FindFirst("appidacr");
+
+                                                if (this.AuthSettings.RolesForApplicationsOnly && authType != null && (authType.Value == "0"))
+                                                {
+                                                    return true;
+                                                }
+                                                return false;
+                                            }
+
+                                            var incommingScopes = roleClaim.Value.Split(' ');
+                                            var accessAllowed = this.AuthSettings.RequiredAppRoles.All(
+                                                s => incommingScopes.Contains(s));
+                                            return accessAllowed;
+                                        });
+        }
+    }
+}

--- a/Core/App.Web/Authentication/Implementations/IAuthententicationMethod.cs
+++ b/Core/App.Web/Authentication/Implementations/IAuthententicationMethod.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal interface IAuthententicationMethod
+    {
+        void Configure(IServiceCollection services, Action<AuthorizationOptions> authorizationOptions);
+        void ConfigureSwaggerAuth(SwaggerGenOptions options, SwaggerSettings swaggerSettings);
+        void UseMiddleware(IApplicationBuilder applicationBuilder);
+        void UseSwaggerUI(SwaggerUIOptions options, SwaggerSettings swaggerSettings);
+        void ApplyMvcFilters(FilterCollection filters);
+    }
+}

--- a/Core/App.Web/Authentication/Implementations/OAuth2Authentication.cs
+++ b/Core/App.Web/Authentication/Implementations/OAuth2Authentication.cs
@@ -1,0 +1,151 @@
+﻿using Lens.Core.App.Web.Services;
+using Lens.Core.Lib.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
+using System.Collections.Generic;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    internal class OAuth2Authentication<T> : AuthenticationBase<T> where T : OAuthSettings
+    {
+        protected static AuthorizationPolicy DefaultPolicy
+        {
+            get =>
+                new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme)
+                    .RequireAuthenticatedUser()
+                    .Build();
+        }
+
+        public OAuth2Authentication(T authSettings) : base(authSettings)
+        {
+        }
+
+        public override void Configure(
+            IServiceCollection services,
+            Action<AuthorizationOptions> authorizationOptions)
+        {
+            services
+                    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                    .AddJwtBearer(options =>
+                    {
+                        options.Audience = this.AuthSettings.Audience;
+                        options.Authority = this.AuthSettings.Authority;
+
+                        if (!string.IsNullOrEmpty(this.AuthSettings.MetadataAddress))
+                            options.MetadataAddress = this.AuthSettings.MetadataAddress;
+
+                        options.RequireHttpsMetadata = this.AuthSettings.RequireHttps;
+                        options.TokenValidationParameters.ValidateAudience = this.AuthSettings.ValidateAudience;
+                        options.TokenValidationParameters.NameClaimType = "name";
+
+                        this.RegisterAuthenticationInterceptorEventHandlers(options);
+                    });
+
+            authorizationOptions ??= options => { options.DefaultPolicy = DefaultPolicy; };
+            services.AddAuthorization(authorizationOptions);
+
+            services.AddHttpContextAccessor();
+            services.AddScoped<IUserContext, UserContext>();
+        }
+
+        public override void ConfigureSwaggerAuth(SwaggerGenOptions options, SwaggerSettings swaggerSettings)
+        {
+            base.ConfigureSwaggerAuth(options, swaggerSettings);
+
+            //https://www.c-sharpcorner.com/article/enable-oauth-2-authorization-using-azure-ad-and-swagger-in-net-5-0/
+            options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.OAuth2,
+                Flows = new OpenApiOAuthFlows
+                {
+                    AuthorizationCode = new OpenApiOAuthFlow
+                    {
+                        AuthorizationUrl = new Uri($"{swaggerSettings.Authority}authorize"),
+                        TokenUrl = new Uri($"{swaggerSettings.Authority}token"),
+                        Scopes = new Dictionary<string, string>
+                                {
+                                    {swaggerSettings.Scope, swaggerSettings.ScopeName}
+                                }
+                    }
+                }
+            });
+
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
+                    },
+                    new[] { swaggerSettings.Scope }
+                }
+            });
+
+            options.OperationFilter<AuthorizeCheckOperationFilter>();
+        }
+
+        public override void UseSwaggerUI(SwaggerUIOptions options, SwaggerSettings swaggerSettings)
+        {
+            base.UseSwaggerUI(options, swaggerSettings);
+
+            //https://lurumad.github.io/swagger-ui-with-pkce-using-swashbuckle-asp-net-core
+            options.OAuthClientId(swaggerSettings.ClientId);
+            options.OAuthClientSecret(swaggerSettings.ClientSecret);
+            options.OAuthUsePkce();
+        }
+
+        protected void RegisterAuthenticationInterceptorEventHandlers(JwtBearerOptions options)
+        {
+            options.Events.OnMessageReceived = async context =>
+            {
+                var interceptors = context.HttpContext.RequestServices.GetServices<IAuthenticationInterceptor>();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.OnMessageReceived(context);
+                }
+            };
+
+            options.Events.OnTokenValidated = async context =>
+            {
+                var interceptors = context.HttpContext.RequestServices.GetServices<IAuthenticationInterceptor>();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.OnTokenValidated(context);
+                }
+            };
+
+            options.Events.OnChallenge = async context =>
+            {
+                var interceptors = context.HttpContext.RequestServices.GetServices<IAuthenticationInterceptor>();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.OnChallenge(context);
+                }
+            };
+
+            options.Events.OnForbidden = async context =>
+            {
+                var interceptors = context.HttpContext.RequestServices.GetServices<IAuthenticationInterceptor>();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.OnForbidden(context);
+                }
+            };
+
+            options.Events.OnAuthenticationFailed = async context =>
+            {
+                var interceptors = context.HttpContext.RequestServices.GetServices<IAuthenticationInterceptor>();
+                foreach (var interceptor in interceptors)
+                {
+                    await interceptor.OnAuthenticationFailed(context);
+                }
+            };
+        }
+    }
+}

--- a/Core/App.Web/Authentication/Interceptors/IAuthenticationInterceptor.cs
+++ b/Core/App.Web/Authentication/Interceptors/IAuthenticationInterceptor.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System;
+using System.Threading.Tasks;
+
+namespace Lens.Core.App.Web.Authentication
+{
+    public interface IAuthenticationInterceptor
+    {
+        Task OnAuthenticationFailed(AuthenticationFailedContext context);
+
+        Task OnForbidden(ForbiddenContext context);
+
+        Task OnMessageReceived(MessageReceivedContext context);
+
+        Task OnTokenValidated(TokenValidatedContext context);
+
+        Task OnChallenge(JwtBearerChallengeContext context);
+    }
+}

--- a/Core/App.Web/Core.App.Web.csproj
+++ b/Core/App.Web/Core.App.Web.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.24.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/App.Web/Extensions/ApplicationBuilderExtensions.cs
+++ b/Core/App.Web/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Lens.Core.App.Web.Authentication;
+using Lens.Core.App.Web.Middleware;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 
 namespace Lens.Core.App.Web
@@ -11,18 +13,51 @@ namespace Lens.Core.App.Web
             return appBuilder;
         }
 
+        public static IApplicationBuilder UseAuthentication(this IApplicationBuilder applicationBuilder, IConfiguration configuration)
+        {
+            var authMethod = AuthenticationFactory.GetAuthenticationMethod(configuration);
+            authMethod.UseMiddleware(applicationBuilder);
+
+            return applicationBuilder;
+        }
+
+        public static IApplicationBuilder UseSwagger(this IApplicationBuilder appBuilder, IConfiguration configuration)
+        {
+            var swaggerSettings = configuration.GetSection(nameof(SwaggerSettings)).Get<SwaggerSettings>();
+
+            if (swaggerSettings is null)
+            {
+                return appBuilder.UseSwagger();
+            }
+
+            appBuilder.UseSwagger(options =>
+            {
+                //Nintex only supports version 2 for now: https://help.nintex.com/en-US/xtensions/04_Reference/REF_KnownIssues.htm
+                if (!string.IsNullOrEmpty(swaggerSettings.OpenAPIVersion) && swaggerSettings.OpenAPIVersion.Equals("2"))
+                {
+                    options.SerializeAsV2 = true;
+                }
+            });
+
+            return appBuilder;
+        }
+
         public static IApplicationBuilder UseSwaggerUI(this IApplicationBuilder appBuilder, IConfiguration configuration)
         {
             var swaggerSettings = configuration.GetSection(nameof(SwaggerSettings)).Get<SwaggerSettings>();
+            var authMethod = AuthenticationFactory.GetAuthenticationMethod(configuration);
+
+            if (swaggerSettings is null)
+            {
+                return appBuilder.UseSwaggerUI();
+            }
 
             appBuilder.UseSwaggerUI(options =>
             {
                 options.SwaggerEndpoint("swagger/v1/swagger.json", swaggerSettings?.AppName ?? "API V1");
                 options.RoutePrefix = string.Empty;
 
-                options.OAuthClientId(swaggerSettings.ClientId);
-                options.OAuthClientSecret(swaggerSettings.ClientSecret);
-                options.OAuthUsePkce();
+                authMethod.UseSwaggerUI(options, swaggerSettings);
             });
             return appBuilder;
         }

--- a/Core/App.Web/Middleware/ApiKeyMiddleware.cs
+++ b/Core/App.Web/Middleware/ApiKeyMiddleware.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.App.Web.Middleware
+{
+    /// <summary>
+    /// A simple API key middleware implementation using the header X-Api-Key
+    /// </summary>
+    public class ApiKeyMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ApiKeyAuthSettings authSettings;
+
+        public ApiKeyMiddleware(RequestDelegate next, IConfiguration configuration)
+        {
+            _next = next;
+            authSettings = configuration.GetSection(nameof(AuthSettings)).Get<ApiKeyAuthSettings>();
+        }
+
+        public async Task Invoke(HttpContext context, IConfiguration configuration)
+        {
+            //var authSettings = configuration.GetSection(nameof(AuthSettings)).Get<ApiKeyAuthSettings>();
+
+            if (!string.IsNullOrEmpty(authSettings.AuthenticationType) && authSettings.AuthenticationType.Equals("apikey", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrEmpty(authSettings.ApiKey) || string.IsNullOrEmpty(authSettings.ApiKeyHeader))
+                {
+                    context.Response.StatusCode = 500;
+                    await context.Response.WriteAsync("API Key authentication is used, but not being configured correctly");
+                    return;
+                }
+
+                if (!context.Request.Headers.ContainsKey(authSettings.ApiKeyHeader))
+                {
+                    context.Response.StatusCode = 400; //Bad Request                
+                    await context.Response.WriteAsync("API Key is missing");
+                    return;
+                }
+
+                if (!authSettings.ApiKey.Equals(context.Request.Headers[authSettings.ApiKeyHeader]))
+                {
+                    context.Response.StatusCode = 401; //UnAuthorized
+                    await context.Response.WriteAsync("Invalid API Key");
+                    return;
+                }
+            }
+            await _next.Invoke(context);
+        }
+    }
+}

--- a/Core/App.Web/ProgramBase.cs
+++ b/Core/App.Web/ProgramBase.cs
@@ -6,8 +6,7 @@ namespace Lens.Core.App.Web
 {
     public abstract class ProgramBase<TStartup> : ProgramBase where TStartup: class
     {
-        public static async Task<int> Start(string[] args) =>
-            await Start(args, CreateWebHostBuilder);
+        public static Task<int> Start(string[] args) => Start(args, CreateWebHostBuilder);
 
         protected static IHostBuilder CreateWebHostBuilder(string[] args) =>
             CreateBaseHostBuilder(args)

--- a/Core/App.Web/Settings/ApiKeyAuthSettings.cs
+++ b/Core/App.Web/Settings/ApiKeyAuthSettings.cs
@@ -1,0 +1,14 @@
+﻿using Lens.Core.App.Web.Authentication;
+using System;
+
+namespace Lens.Core.App.Web
+{
+    public class ApiKeyAuthSettings : AuthSettings
+    {
+        public override string AuthenticationType => AuthenticationMethod.ApiKey;
+
+        public string ApiKeyHeader { get; set; } = "X-Api-Key";
+
+        public string ApiKey { get; set; }
+    }
+}

--- a/Core/App.Web/Settings/AuthSettings.cs
+++ b/Core/App.Web/Settings/AuthSettings.cs
@@ -1,11 +1,7 @@
 ﻿namespace Lens.Core.App.Web
 {
-    public class AuthSettings
+    public abstract class AuthSettings
     {
-        public string Authority { get; set; }
-        public string Audience { get; set; }
-        public bool RequireHttps { get; set; } = true;
-        public bool ValidateAudience { get; set; } = false;
-        public string MetadataAddress { get; set; }
+        public abstract string AuthenticationType { get; }
     }
 }

--- a/Core/App.Web/Settings/AzureAuthSettings.cs
+++ b/Core/App.Web/Settings/AzureAuthSettings.cs
@@ -1,0 +1,18 @@
+﻿using Lens.Core.App.Web.Authentication;
+using System;
+
+namespace Lens.Core.App.Web
+{
+    public class AzureAuthSettings : OAuthSettings
+    {
+        public override string AuthenticationType => AuthenticationMethod.AzureAd;
+
+        public string[] AllowedIssuers { get; set; } = Array.Empty<string>();
+        public string[] RequiredScopes { get; set; } = Array.Empty<string>();
+        public string[] RequiredAppRoles { get; set; } = Array.Empty<string>();
+
+        public bool IncludeConfigInBearerHeader { get; set; }
+
+        public bool RolesForApplicationsOnly { get; set; }
+    }
+}

--- a/Core/App.Web/Settings/OAuthSettings.cs
+++ b/Core/App.Web/Settings/OAuthSettings.cs
@@ -1,0 +1,16 @@
+﻿using Lens.Core.App.Web.Authentication;
+using System;
+
+namespace Lens.Core.App.Web
+{
+    public class OAuthSettings : AuthSettings
+    {
+        public override string AuthenticationType => AuthenticationMethod.OAuth2;
+        public string Authority { get; set; }
+        public string Audience { get; set; }
+        public string Resource { get; set; }
+        public bool RequireHttps { get; set; } = true;
+        public bool ValidateAudience { get; set; } = false;
+        public string MetadataAddress { get; set; }
+    }
+}

--- a/Core/App.Web/Settings/SwaggerSettings.cs
+++ b/Core/App.Web/Settings/SwaggerSettings.cs
@@ -8,5 +8,8 @@
         public string ClientSecret { get; set; }
         public string Scope { get; set; }
         public string ScopeName { get; set; }
+        public string OpenAPIVersion { get; set; } = "3";
+        public string ApiHostname { get; set; }
+        public string XMLCommentsPath { get; set; }
     }
 }

--- a/Core/App.Web/StartupBase.cs
+++ b/Core/App.Web/StartupBase.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Lens.Core.App.Web.Authentication;
 
 namespace Lens.Core.App.Web
 {
@@ -46,9 +47,11 @@ namespace Lens.Core.App.Web
                 .AddCors(Configuration)
                 .AddSwagger(Configuration);
 
+            var authMethod = AuthenticationFactory.GetAuthenticationMethod(Configuration);
             services.AddControllers(config =>
             {
                 config.Filters.Add(new AuthorizeFilter());
+                authMethod.ApplyMvcFilters(config.Filters);
             });
 
             applicationSetup.AddApplicationServices();
@@ -56,7 +59,7 @@ namespace Lens.Core.App.Web
 
         public virtual void OnSetupApplication(IApplicationSetupBuilder applicationSetup) { }
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -66,10 +69,10 @@ namespace Lens.Core.App.Web
             app.UseCors();
 
             app
-                .UseSwagger()
+                .UseSwagger(Configuration)
                 .UseSwaggerUI(Configuration);
 
-            app.UseAuthentication();
+            app.UseAuthentication(Configuration);
 
             app.UseErrorHandling();
 

--- a/Core/App/Core.App.csproj
+++ b/Core/App/Core.App.csproj
@@ -2,7 +2,9 @@
 
   <ItemGroup>
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.KeyPerFile" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Core/Core.Lib.Azure/Core.Lib.Azure.csproj
+++ b/Core/Core.Lib.Azure/Core.Lib.Azure.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.5" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.1.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.AzureApp" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Core.Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Core/Core.Lib.Azure/Extensions/ApplicationSetupBuilderExtensions.cs
+++ b/Core/Core.Lib.Azure/Extensions/ApplicationSetupBuilderExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Lens.Core.Lib.Builders;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Lib.Azure.Extensions
+{
+    public static class ApplicationSetupBuilderExtensions
+    {
+        public static IApplicationSetupBuilder AddAzureApplicationsInsightsForWeb(this IApplicationSetupBuilder applicationSetup)
+        {
+            applicationSetup.Services.AddApplicationInsightsTelemetry(applicationSetup.Configuration);
+
+            return applicationSetup;
+        }
+
+        public static IApplicationSetupBuilder AddAzureApplicationsInsightsForWorkers(this IApplicationSetupBuilder applicationSetup)
+        {
+            applicationSetup.Services.AddApplicationInsightsTelemetryWorkerService(applicationSetup.Configuration);
+
+            return applicationSetup;
+        }
+    }
+}

--- a/Core/Core.Lib.Azure/Extensions/ConfigurationExtensions.cs
+++ b/Core/Core.Lib.Azure/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Lib.Azure.Extensions
+{
+    public static class ConfigurationExtensions
+    {
+        public static IConfigurationBuilder AddAzureKeyVaultConfigProvider(this IConfigurationBuilder config, TokenCredential? credential = null, string configKeyName = "KeyVault:Vault")
+        {
+            var root = config.Build();
+
+            if (credential is null)
+            {
+                credential = new DefaultAzureCredential();
+            }
+
+            // use managed identities in Azure Web Apps or user-secrets in development environments
+            var keyvaultName = root[configKeyName];
+
+            if (!string.IsNullOrEmpty(keyvaultName))
+            {
+                config.AddAzureKeyVault(new Uri($"https://{keyvaultName}.vault.azure.net/"), credential);
+            }
+
+            return config;
+        }
+    }
+}

--- a/Core/Core.Lib.Azure/Extensions/LoggingExtensions.cs
+++ b/Core/Core.Lib.Azure/Extensions/LoggingExtensions.cs
@@ -1,0 +1,57 @@
+﻿using Lens.Core.Lib.Azure.Logging;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Events;
+
+namespace Lens.Core.Lib.Azure.Extensions
+{
+    public static class LoggingExtensions
+    {
+        public static LoggerConfiguration WithOperationId(this LoggerEnrichmentConfiguration enrichConfiguration)
+        {
+            if (enrichConfiguration is null) throw new ArgumentNullException(nameof(enrichConfiguration));
+
+            return enrichConfiguration.With<OperationIdEnricher>();
+        }
+
+        public static LoggerConfiguration AddAzureAppLogging(this LoggerConfiguration loggerConfiguration, IConfiguration configuration, bool isBootstrap = false)
+        {
+            var appInsightsConnectionstring = configuration.GetValue<string>("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+            if (!string.IsNullOrWhiteSpace(appInsightsConnectionstring))
+            {
+                var config = TelemetryConfiguration.CreateFromConfiguration(appInsightsConnectionstring);
+                config.InstrumentationKey = ParseFromConnectionString(appInsightsConnectionstring);
+
+                return loggerConfiguration
+                    .Enrich.FromLogContext()
+                    .Enrich.WithOperationId()
+                    .WriteTo.AzureApp()
+                    .WriteTo.ApplicationInsights(
+                                config,
+                                new OperationTelemetryConverter(),
+                                LogEventLevel.Information); //https://oleh-zheleznyak.blogspot.com/2019/08/serilog-with-application-insights.html
+            }
+
+            return loggerConfiguration;
+        }
+
+        /// <summary>
+        /// Serilog doesn't seems to handle the telemetry config created from the connectionstring properly
+        /// So we need to set the deprecated instrumentation key to get serilog to work.
+        /// Sould be remove as soon as serilog also has upgraded the the application insights connection string.
+        /// </summary>
+        /// <param name="appInsightsConnectionstring">The application insights connectionstring.</param>
+        /// <returns>Instrumentation key</returns>
+        private static string ParseFromConnectionString(string appInsightsConnectionstring)
+        {
+            var parts = appInsightsConnectionstring.Split(';');
+            var part = parts.FirstOrDefault(p => p.StartsWith("InstrumentationKey="));
+            var key = part?.Split('=')[1];
+
+            return key ?? string.Empty;
+        }
+    }
+}

--- a/Core/Core.Lib.Azure/Logging/AzureAppSink.cs
+++ b/Core/Core.Lib.Azure/Logging/AzureAppSink.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.Logging;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Lib.Azure.Logging
+{
+    public class AzureAppSink : ILogEventSink
+    {
+        /// <summary>
+        /// Our very own Microsoft.Extensions.LoggerFactory, this is where we'll send Serilog events so that Azure can pick up the logs.
+        /// We expect that Serilog has replaced this in the app's services.
+        /// </summary>
+        static ILoggerFactory CoreLoggerFactory { get; } = LoggerFactory.Create(builder => builder.AddAzureWebAppDiagnostics());
+
+        /// <summary>
+        /// The Microsoft.Extensions.LoggerFactory implementation of CreateLogger(string category) uses lock(_sync) before looking in its dictionary.
+        /// We'll use our own ConcurrentDictionary for performance, since we lookup the category on every log write.
+        /// </summary>
+        readonly ConcurrentDictionary<string, Microsoft.Extensions.Logging.ILogger> loggerCategories = new ConcurrentDictionary<string, Microsoft.Extensions.Logging.ILogger>();
+
+        readonly ITextFormatter textFormatter;
+
+        public AzureAppSink(ITextFormatter textFormatter)
+        {
+            this.textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null)
+                throw new ArgumentNullException(nameof(logEvent));
+
+            var sr = new StringWriter();
+            textFormatter.Format(logEvent, sr);
+            var text = sr.ToString().Trim();
+
+            var category = logEvent.Properties.TryGetValue("SourceContext", out var value) ? value.ToString() : "";
+            var logger = loggerCategories.GetOrAdd(category, s => CoreLoggerFactory.CreateLogger(s));
+
+            switch (logEvent.Level)
+            {
+                case LogEventLevel.Fatal:
+                    logger.LogCritical(text);
+                    break;
+                case LogEventLevel.Error:
+                    logger.LogError(text);
+                    break;
+                case LogEventLevel.Warning:
+                    logger.LogWarning(text);
+                    break;
+                case LogEventLevel.Information:
+                    logger.LogInformation(text);
+                    break;
+                case LogEventLevel.Debug:
+                    logger.LogDebug(text);
+                    break;
+                case LogEventLevel.Verbose:
+                    logger.LogTrace(text);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("logeventlevel");
+            }
+        }
+    }
+}

--- a/Core/Core.Lib.Azure/Logging/OperationIdEnricher.cs
+++ b/Core/Core.Lib.Azure/Logging/OperationIdEnricher.cs
@@ -1,0 +1,32 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Lib.Azure.Logging
+{
+    public class OperationIdEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            var activity = Activity.Current;
+
+            if (activity is null) return;
+
+            logEvent.AddPropertyIfAbsent(new LogEventProperty("Operation Id", new ScalarValue(activity.TraceId)));
+            //logEvent.AddPropertyIfAbsent(new LogEventProperty("Operation Id", new ScalarValue(activity.Id)));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty("Parent Id", new ScalarValue(activity.ParentId)));
+
+            if (activity.Parent != null)
+            {
+                // Like internal method in AI W3CUtilities.FormatTelemetryId
+                var parentId = $"|{activity.TraceId}.{activity.Parent.SpanId}.";
+                logEvent.AddPropertyIfAbsent(new LogEventProperty("Operation Id", new ScalarValue(parentId)));
+            }
+        }
+    }
+}

--- a/Core/Core.Lib.Azure/Logging/OperationTelemetryConverter.cs
+++ b/Core/Core.Lib.Azure/Logging/OperationTelemetryConverter.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Lib.Azure.Logging
+{
+    public class OperationTelemetryConverter : TraceTelemetryConverter
+    {
+        const string OperationId = "Operation Id";
+        const string ParentId = "Parent Id";
+
+        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            foreach (var telemetry in base.Convert(logEvent, formatProvider))
+            {
+                if (TryGetScalarProperty(logEvent, OperationId, out var operationId) && operationId != null)
+                    telemetry.Context.Operation.Id = operationId.ToString();
+
+                if (TryGetScalarProperty(logEvent, ParentId, out var parentId) && parentId != null)
+                    telemetry.Context.Operation.ParentId = parentId.ToString();
+
+                yield return telemetry;
+            }
+        }
+
+        private bool TryGetScalarProperty(LogEvent logEvent, string propertyName, out object value)
+        {
+            var hasScalarValue =
+                logEvent.Properties.TryGetValue(propertyName, out var someValue) &&
+                (someValue is ScalarValue);
+
+            value = hasScalarValue ? (someValue as ScalarValue)?.Value : default;
+
+            return hasScalarValue;
+        }
+    }
+}

--- a/Core/Data.EF/Core.Data.EF.csproj
+++ b/Core/Data.EF/Core.Data.EF.csproj
@@ -8,6 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.1.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.15" />
   </ItemGroup>
 

--- a/Core/Data.EF/Extensions/LoggingExtensions.cs
+++ b/Core/Data.EF/Extensions/LoggingExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Serilog;
+using Serilog.Exceptions;
+using Serilog.Exceptions.Core;
+using Serilog.Exceptions.EntityFrameworkCore.Destructurers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lens.Core.Data.EF.Extensions
+{
+    public static class LoggingExtensions
+    {
+        public static LoggerConfiguration AddEFCoreLogging(this LoggerConfiguration loggerConfiguration, bool isBootstrap = false)
+        {
+            if (isBootstrap)
+            {
+                return loggerConfiguration;
+            }
+
+            return loggerConfiguration
+                .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder()
+                                                    .WithDefaultDestructurers()
+                                                    .WithDestructurers(new[] { new DbUpdateExceptionDestructurer() })
+                                            );
+        }
+    }
+}

--- a/Core/Lib/Core.Lib.csproj
+++ b/Core/Lib/Core.Lib.csproj
@@ -5,7 +5,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
 
     <PackageReference Include="AutoMapper.Extensions.ExpressionMapping" Version="5.0.0" />
@@ -13,7 +13,7 @@
 
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
 
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
   </ItemGroup>
   
 </Project>

--- a/Core/Lib/Extensions/HttpClientExtensions.cs
+++ b/Core/Lib/Extensions/HttpClientExtensions.cs
@@ -7,7 +7,7 @@ namespace Lens.Core.Lib
 {
 	public static class HttpClientExtensions
 	{
-        public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string url, Action<HttpRequestHeaders> beforeRequest, HttpContent content = null)
+    public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string url, Action<HttpRequestHeaders> beforeRequest, HttpContent content = null)
 		{
 			var request = new HttpRequestMessage(HttpMethod.Get, url);
 
@@ -38,6 +38,7 @@ namespace Lens.Core.Lib
 		private static Task<HttpResponseMessage> SendRequest(HttpClient httpClient, Action<HttpRequestHeaders> beforeRequest, HttpContent content, HttpRequestMessage request)
 		{
 			beforeRequest(request.Headers);
+
 			if (content != null)
 			{
 				request.Content = content;

--- a/Core/Lib/Utilities/PasswordGenerator.cs
+++ b/Core/Lib/Utilities/PasswordGenerator.cs
@@ -24,33 +24,6 @@ namespace Lens.Core.Lib.Utilities
         private static string PASSWORD_CHARS_NUMERIC = "123456789";
         private static string PASSWORD_CHARS_SPECIAL = "_-!*:;\\/|~";
 
-        //private static Zxcvbn.Zxcvbn zx = null;
-
-        //public static Zxcvbn.Zxcvbn PasswordStrengthLib
-        //{
-        //    get
-        //    {
-        //        if (zx == null)
-        //        {
-        //            zx = new Zxcvbn.Zxcvbn();
-        //        }
-
-        //        return zx;
-        //    }
-        //}
-
-        /// <summary>
-        /// Measure the password strength, based on the DropBox Zxcvbn, which is a battle tested method.
-        /// You can use userInputs to check against other information of the user, if the password doesn't contain that information.
-        /// </summary>
-        /// <param name="password">the password to check</param>
-        /// <param name="userInputs">a list of strings which contain information you don't want in your password, so the library will check for it</param>
-        /// <returns></returns>
-        //public static Zxcvbn.Result PasswordStrength(string password, IEnumerable<string> userInputs = null)
-        //{
-        //    return PasswordStrengthLib.EvaluatePassword(password, userInputs);
-        //}
-
         /// <summary>
         /// Generates a random password.
         /// </summary>
@@ -288,7 +261,6 @@ namespace Lens.Core.Lib.Utilities
             }
 
             // Generate 4 random bytes.
-            RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider();
             rng.GetBytes(randomBytes);
 
             // Convert 4 bytes into a 32-bit integer value.


### PR DESCRIPTION
* Allow for dbcontext without IAudittrailService.

* Added random string generation utility

* Add Dapper to the base-data library.

* Add Lens.Services.Masterdata project as a startingpoint for Masterdata microservice.

* Added method to read and execute all sql files in a folder

* Added bulk file revert for Migration.Down()

* Add base repositories as generic services.

* Proper abstraction and usage of BaseRepositories.

* Added much used extensions. Sequential GUIDs. Password Generator. Changed Serilog to appreciate the appsettings configuration

* better debugging

* added extended logging. Authentication mechanism. Add an Azure library.

* remove comments

* fix comment

* unneeded await

* Added AzureAD auth + refactored authentication methods to use a factory (#6)

* Added AzureAD auth + refactored authentication methods to use a factory
* Created separate settings for each authentication method

* Extended Swagger Configuration

* Added logic to add a custom event handler to the JwtBearerOptions.Events

* fixed bug

* Breaking change: Removed the hardcoded /connect from the authorization and token endpoint to support azure Ad authentication. All apps using de default oauth2 implementation must update there Authority url to end with /connect

* Possible breaking change: added security requirement in the Oauth authentication method

* Remove deprecated random number generator

* Ability to override configure function in startup

* fix API key authentication

* Updated app insights logger

* Updated app insights extension

* fixed bug

* add swagger annotations

* Add resource as config (temporarily)

* Ability to add oauth settings in authentication header (MS platform requirements)

* Nuget Packages update

* fix app and user authentication mixup

Co-authored-by: Johan Hoek <johanh@od.org>
Co-authored-by: Michiel Eghuizen <michiele@od.org>
Co-authored-by: Johanh-od <102743218+Johanh-od@users.noreply.github.com>
Co-authored-by: Michiel <michieleghuizen@gmail.com>