### PR TITLE
Added row level security support for audit logging

### DIFF
--- a/Core/Data.EF.SqlServer/Core.Data.EF.SqlServer/AuditTrail/Extensions/AuditTrailSetupBuilderExtensions.cs
+++ b/Core/Data.EF.SqlServer/Core.Data.EF.SqlServer/AuditTrail/Extensions/AuditTrailSetupBuilderExtensions.cs
@@ -39,7 +39,7 @@ public static class AuditTrailSetupBuilderExtensions
        string connectionStringPassword = "dbPassword") where T : class, IAuditRlsIdentityProvider
     {
         builder.Services.Configure<AuditSettings>(options => builder.Configuration.Bind(nameof(AuditSettings), options));
-        builder.Services.AddTransient<IAuditRlsIdentityProvider, T>();
+        builder.Services.AddScoped<IAuditRlsIdentityProvider, T>();
         return builder.AddAuditTrailing(connectionStringName, connectionStringPassword);
     }
 }

--- a/Core/Data.EF.SqlServer/Core.Data.EF.SqlServer/AuditTrail/Extensions/AuditTrailSetupBuilderExtensions.cs
+++ b/Core/Data.EF.SqlServer/Core.Data.EF.SqlServer/AuditTrail/Extensions/AuditTrailSetupBuilderExtensions.cs
@@ -1,15 +1,20 @@
-﻿using Lens.Core.Data.EF.AuditTrail.Services;
+﻿using Lens.Core.Data.EF.AuditTrail.RowLevelSecurity.Providers;
+using Lens.Core.Data.EF.AuditTrail.Services;
+using Lens.Core.Data.EF.Configuration;
+using Lens.Core.Data.EF.RowLevelSecurity.Interceptors;
 using Lens.Core.Data.Services;
 using Lens.Core.Lib;
 using Lens.Core.Lib.Builders;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Lens.Core.Data.EF.AuditTrail;
 
 public static class AuditTrailSetupBuilderExtensions
 {
-    public static IApplicationSetupBuilder AddAuditTrailing(this IApplicationSetupBuilder builder, 
-        string connectionStringName = "DefaultConnection", 
+    public static IApplicationSetupBuilder AddAuditTrailing(this IApplicationSetupBuilder builder,
+        string connectionStringName = "DefaultConnection",
         string connectionStringPassword = "dbPassword")
     {
         builder
@@ -17,8 +22,24 @@ public static class AuditTrailSetupBuilderExtensions
             .AddAssemblies(typeof(AutoMapperProfile).Assembly)
             .AddSqlServerDatabase<AuditTrailDbContext>(connectionStringName, connectionStringPassword, typeof(AuditTrailSetupBuilderExtensions).Assembly)
             .Services
-                .AddScoped<IAuditTrailService, AuditTrailService>();
+                .AddScoped<IAuditTrailService, AuditTrailService>()
+                .AddScoped<IDbCommandInterceptor, RowLevelSecurityInterceptor>();
 
         return builder;
+    }
+    /// <summary>
+    /// Add audit trailing that's configured to work with Row Level Security (rls) by providing the rls identity on data read and write.
+    /// </summary>
+    /// <typeparam name="T">Your custom logic to get the rls identity for the current user.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <param name="connectionStringName">The connection string name.</param>
+    /// <param name="connectionStringPassword">the connection string password.</param>
+    public static IApplicationSetupBuilder AddAuditTrailingWithRlsSupport<T>(this IApplicationSetupBuilder builder,
+       string connectionStringName = "DefaultConnection",
+       string connectionStringPassword = "dbPassword") where T : class, IAuditRlsIdentityProvider
+    {
+        builder.Services.Configure<AuditSettings>(options => builder.Configuration.Bind(nameof(AuditSettings), options));
+        builder.Services.AddTransient<IAuditRlsIdentityProvider, T>();
+        return builder.AddAuditTrailing(connectionStringName, connectionStringPassword);
     }
 }

--- a/Core/Data.EF/AuditTrail/AuditTrailDbContext.cs
+++ b/Core/Data.EF/AuditTrail/AuditTrailDbContext.cs
@@ -1,17 +1,42 @@
 ﻿using Lens.Core.Data.EF.AuditTrail.Entities;
+using Lens.Core.Data.EF.AuditTrail.RowLevelSecurity.Providers;
+using Lens.Core.Data.EF.Configuration;
+using Lens.Core.Data.EF.RowLevelSecurity.Interceptors;
 using Lens.Core.Data.EF.Services;
 using Lens.Core.Lib.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Lens.Core.Data.EF.AuditTrail;
 
 public class AuditTrailDbContext : ApplicationDbContext
 {
-    public AuditTrailDbContext(DbContextOptions<AuditTrailDbContext> options, IUserContext userContext, IEnumerable<IModelBuilderService> modelBuilders) : base(options, userContext, modelBuilders)
+    private readonly IAuditRlsIdentityProvider? rlsIdentityProvider;
+    private readonly AuditSettings auditSettings;
+
+    public AuditTrailDbContext(
+        DbContextOptions<AuditTrailDbContext> options,
+        IUserContext userContext,
+        IEnumerable<IModelBuilderService> modelBuilders,
+        IOptions<AuditSettings> auditSettings,
+        IAuditRlsIdentityProvider? rlsIdentityProvider)
+        : base(options, userContext, modelBuilders)
     {
+        this.rlsIdentityProvider = rlsIdentityProvider;
+        this.auditSettings = auditSettings.Value;
     }
 
     public DbSet<EntityChange> EntityChanges { get; set; } = null!;
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        if (this.auditSettings.EnableRlsSupport)
+        {
+            optionsBuilder.AddInterceptors(new RowLevelSecurityInterceptor(rlsIdentityProvider));
+        }
+
+        base.OnConfiguring(optionsBuilder);
+    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Core/Data.EF/AuditTrail/RowLevelSecurity/Providers/IAuditRlsIdentityProvider.cs
+++ b/Core/Data.EF/AuditTrail/RowLevelSecurity/Providers/IAuditRlsIdentityProvider.cs
@@ -1,0 +1,8 @@
+﻿using Lens.Core.Data.EF.RowLevelSecurity.Providers;
+
+namespace Lens.Core.Data.EF.AuditTrail.RowLevelSecurity.Providers
+{
+    public interface IAuditRlsIdentityProvider : IRowLevelSecurityIdentityProvider
+    {
+    }
+}

--- a/Core/Data.EF/Configuration/AuditSettings.cs
+++ b/Core/Data.EF/Configuration/AuditSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace Lens.Core.Data.EF.Configuration
+{
+    public class AuditSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating that we should add a command interceptor to wrap each query in a user context.
+        /// </summary>
+        public bool EnableRlsSupport { get; set; }
+    }
+}

--- a/Core/Data.EF/RowLevelSecurity/Interceptors/RowLevelSecurityInterceptor.cs
+++ b/Core/Data.EF/RowLevelSecurity/Interceptors/RowLevelSecurityInterceptor.cs
@@ -1,0 +1,46 @@
+﻿using Lens.Core.Data.EF.RowLevelSecurity.Providers;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+
+namespace Lens.Core.Data.EF.RowLevelSecurity.Interceptors
+{
+    public class RowLevelSecurityInterceptor : DbCommandInterceptor
+    {
+        private readonly IRowLevelSecurityIdentityProvider rlsIdentityProvider;
+
+        public RowLevelSecurityInterceptor(IRowLevelSecurityIdentityProvider? rlsIdentityProvider)
+        {
+            this.rlsIdentityProvider = rlsIdentityProvider ?? throw new ArgumentNullException(nameof(rlsIdentityProvider));
+        }
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            AddUserContextToQuery(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result, CancellationToken cancellationToken = default)
+        {
+            AddUserContextToQuery(command);
+            return new ValueTask<InterceptionResult<DbDataReader>>(result);
+        }
+
+        private void AddUserContextToQuery(DbCommand command)
+        {
+            if (rlsIdentityProvider.HasAuthenticatedUser)
+            {
+                
+                var principleId = rlsIdentityProvider.GetUserRowLevelSecurityIdentity();
+                if(Regex.IsMatch(principleId, "^(?!.*--)[a-zA-Z0-9-]+$"))
+                {
+                    command.CommandText = $"EXECUTE AS USER = '{principleId}'; {command.CommandText}; REVERT;";
+                }
+                else
+                {
+                    throw new InvalidOperationException("provided principle id contains invalid characters.");
+                }
+            }
+        }
+    }
+}

--- a/Core/Data.EF/RowLevelSecurity/Providers/IRowLevelSecurityIdentityProvider.cs
+++ b/Core/Data.EF/RowLevelSecurity/Providers/IRowLevelSecurityIdentityProvider.cs
@@ -1,0 +1,13 @@
+﻿namespace Lens.Core.Data.EF.RowLevelSecurity.Providers
+{
+    public interface IRowLevelSecurityIdentityProvider
+    {
+        bool HasAuthenticatedUser { get; }
+
+        /// <summary>
+        /// Gets the unique id that is used to execute the SQL query in the user's context.
+        /// </summary>
+        /// <returns></returns>
+        public string GetUserRowLevelSecurityIdentity();
+    }
+}


### PR DESCRIPTION
We've added rls to our audit table so a user cannot see the audit logs for the database records he/she doesn't have access to. Created a new extension method that uses audit logging with a sql interceptor and added configuration settings to enable or disable rls interceptor injection (while using the auditlog with rls support)