### PR TITLE
Assembly specific dependencies bugfix

### DIFF
--- a/Core/App.Console/ProgramBase.cs
+++ b/Core/App.Console/ProgramBase.cs
@@ -17,5 +17,6 @@ public abstract class ProgramBase : App.ProgramBase
                     var applicationSetup = new ApplicationSetupBuilder (services, context.Configuration);
                     ApplicationSetup?.Invoke(context, applicationSetup);
                     applicationSetup.AddApplicationServices();
+                    applicationSetup.AddAssemblySpecificApplicationServices();
                 });
 }

--- a/Core/App.Web/StartupBase.cs
+++ b/Core/App.Web/StartupBase.cs
@@ -67,6 +67,8 @@ public class StartupBase
         applicationSetup.AddApplicationServices();
 
         OnSetupApplication(applicationSetup);
+
+        applicationSetup.AddAssemblySpecificApplicationServices();
     }
 
     private static void ConfigureControllers(MvcOptions options, WebApplicationSetupBuilder applicationSetup)

--- a/Core/App/Extensions/ApplicationSetupBuilderExtensions.cs
+++ b/Core/App/Extensions/ApplicationSetupBuilderExtensions.cs
@@ -11,12 +11,24 @@ public static class ApplicationSetupBuilderExtensions
     public static IApplicationSetupBuilder AddApplicationServices(this IApplicationSetupBuilder applicationSetup)
     {
         applicationSetup
-            .AddAutoMapper()
-            .AddMediatR()
             .AddBackgroundTaskQueue()
             .Services
                 .AddScoped(typeof(IApplicationService<>), typeof(ApplicationService<>))
                 .AddScoped(typeof(IApplicationService<,>), typeof(ApplicationService<,>));
+
+        return applicationSetup;
+    }
+
+    /// <summary>
+    /// These services are dependent on the assemblies you add to the services for scanning, so should run AFTER the service collection has been built.
+    /// </summary>
+    /// <param name="applicationSetup"></param>
+    /// <returns></returns>
+    public static IApplicationSetupBuilder AddAssemblySpecificApplicationServices(this IApplicationSetupBuilder applicationSetup)
+    {
+        applicationSetup
+            .AddAutoMapper()
+            .AddMediatR();
 
         return applicationSetup;
     }


### PR DESCRIPTION
Assembly specific dependencies should ONLY be added after all assemblies have been registered. Automapper and MediatR are depended on the registered assemblies in the Assembly list